### PR TITLE
[CLD-2570] Enhance rotator to support node drains

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ rotator cluster rotate --cluster <cluster_id> --rotate-workers --rotate-masters 
 
 You will get a response like this one:
 ```bash
-[{
+{
     "ClusterID": "<cluster_id>",
     "MaxScaling": 4,
     "RotateMasters": true,
@@ -87,6 +87,26 @@ You will get a response like this one:
     "ClientSet": null
 }
 ```
+
+In a different terminal/window, to drain a node:
+```bash
+rotator drain --node <node_name> --detach --cluster <cluster_id> --terminate --wait-between-pod-evictions 2 --evict-grace-period 60 --max-drain-retries 10
+```
+
+You will get a response like this one:
+```bash
+{
+    "NodeName": "<node_name>",
+    "GracePeriod": 60,
+    "WaitBetweenPodEvictions": 2,
+    "MaxDrainRetries": 10,
+    "DetachNode": true,
+    "TerminateNode": true,
+    "ClusterID": "<cluster_id"
+}
+```
+
+The detach and terminate node options are optional during a drain operation. When set to true the `--cluster` flag is required.
 
 ### Other Setup
 

--- a/api/api.go
+++ b/api/api.go
@@ -85,6 +85,9 @@ func handleDrainNode(c *Context, w http.ResponseWriter, r *http.Request) {
 		GracePeriod:             drainNodeRequest.GracePeriod,
 		MaxDrainRetries:         drainNodeRequest.MaxDrainRetries,
 		WaitBetweenPodEvictions: drainNodeRequest.WaitBetweenPodEvictions,
+		DetachNode:              drainNodeRequest.DetachNode,
+		TerminateNode:           drainNodeRequest.TerminateNode,
+		ClusterID:               drainNodeRequest.ClusterID,
 	}
 
 	go rotator.InitDrainNode(&node, c.Logger.WithField("node", node.NodeName))

--- a/aws/helpers.go
+++ b/aws/helpers.go
@@ -178,6 +178,10 @@ func AutoScalingGroupReady(autoscalingGroupName string, desiredCapacity int, log
 	}
 }
 
+func NodeInAutoscalingGroup(autoscalingGroupName, instanceID string) (bool, error) {
+	return nodeInAutoscalingGroup(autoscalingGroupName, instanceID)
+}
+
 // nodeInAutoscalingGroup checks if an instance is member of an Autoscaling Group.
 func nodeInAutoscalingGroup(autoscalingGroupName, instanceID string) (bool, error) {
 	svc := autoscaling.New(session.New())

--- a/cmd/rotator/main.go
+++ b/cmd/rotator/main.go
@@ -20,7 +20,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(serverCmd)
 	rootCmd.AddCommand(clusterCmd)
-	rootCmd.AddCommand(nodeCmd)
+	rootCmd.AddCommand(drainCmd)
 }
 
 func main() {

--- a/cmd/rotator/rotator.go
+++ b/cmd/rotator/rotator.go
@@ -26,6 +26,9 @@ func init() {
 	drainCmd.Flags().Int("evict-grace-period", 60, "the pod eviction grace period")
 	drainCmd.Flags().Int("wait-between-pod-evictions", 2, "the time in seconds between each pod eviction in a drain")
 	drainCmd.Flags().Int("max-drain-retries", 10, "the max number of retries when drain fails")
+	drainCmd.Flags().Bool("detach", false, "whether to detach the node from its autoscaling group")
+	drainCmd.Flags().Bool("terminate", false, "whether to terminate the node")
+	drainCmd.Flags().String("cluster", "", "the cluster ID of the cluster to that the node will be drained. Needed when detach is required")
 
 	drainCmd.MarkFlagRequired("node") //nolint
 
@@ -51,12 +54,18 @@ var drainCmd = &cobra.Command{
 		gracePeriod, _ := command.Flags().GetInt("evict-grace-period")
 		waitBetweenPodEvictions, _ := command.Flags().GetInt("wait-between-pod-evictions")
 		maxDrainRetries, _ := command.Flags().GetInt("max-drain-retries")
+		detachNode, _ := command.Flags().GetBool("detach")
+		terminateNode, _ := command.Flags().GetBool("terminate")
+		clusterID, _ := command.Flags().GetString("cluster")
 
 		drain, err := client.DrainNode(&model.DrainNodeRequest{
 			NodeName:                nodeName,
 			GracePeriod:             gracePeriod,
 			WaitBetweenPodEvictions: waitBetweenPodEvictions,
 			MaxDrainRetries:         maxDrainRetries,
+			DetachNode:              detachNode,
+			TerminateNode:           terminateNode,
+			ClusterID:               clusterID,
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to drain node")

--- a/cmd/rotator/rotator.go
+++ b/cmd/rotator/rotator.go
@@ -22,7 +22,15 @@ func init() {
 	rotatorCmd.Flags().Int("wait-between-drains", 60, "the time in seconds between each node drain")
 	rotatorCmd.Flags().Int("wait-between-pod-evictions", 0, "the time in seconds between each pod eviction in a drain")
 
+	drainCmd.Flags().String("node", "", "the name of the node to do drain operations")
+	drainCmd.Flags().Int("evict-grace-period", 60, "the pod eviction grace period")
+	drainCmd.Flags().Int("wait-between-pod-evictions", 2, "the time in seconds between each pod eviction in a drain")
+	drainCmd.Flags().Int("max-drain-retries", 10, "the max number of retries when drain fails")
+
+	drainCmd.MarkFlagRequired("node") //nolint
+
 	clusterCmd.AddCommand(rotatorCmd)
+	clusterCmd.AddCommand(drainCmd)
 }
 
 var clusterCmd = &cobra.Command{
@@ -31,9 +39,35 @@ var clusterCmd = &cobra.Command{
 }
 
 // TODO: Add node handling capabilities
-var nodeCmd = &cobra.Command{
-	Use:   "node",
-	Short: "Handle node changees, drain, detach, terminate, etc.",
+var drainCmd = &cobra.Command{
+	Use:   "drain",
+	Short: "Handle node drain.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		nodeName, _ := command.Flags().GetString("node")
+		gracePeriod, _ := command.Flags().GetInt("evict-grace-period")
+		waitBetweenPodEvictions, _ := command.Flags().GetInt("wait-between-pod-evictions")
+		maxDrainRetries, _ := command.Flags().GetInt("max-drain-retries")
+
+		drain, err := client.DrainNode(&model.DrainNodeRequest{
+			NodeName:                nodeName,
+			GracePeriod:             gracePeriod,
+			WaitBetweenPodEvictions: waitBetweenPodEvictions,
+			MaxDrainRetries:         maxDrainRetries,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to drain node")
+		}
+		err = printJSON(drain)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
 }
 
 var rotatorCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1
 	golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5 // indirect
+	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b // indirect
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 // indirect
 	k8s.io/api v0.18.15
 	k8s.io/apimachinery v0.18.15

--- a/go.sum
+++ b/go.sum
@@ -223,7 +223,6 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -265,7 +264,6 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
@@ -298,7 +296,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
@@ -427,7 +424,6 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -446,6 +442,8 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b h1:2n253B2r0pYSmEV+UNCQoPfU/FiaizQEK5Gu4Bq4JE8=
+golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -571,7 +569,6 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
-google.golang.org/grpc v1.31.0 h1:T7P4R73V3SSDPhH7WW7ATbfViLtmamH0DKrP3f9AuDI=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -585,7 +582,6 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -595,13 +591,11 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/model/client.go
+++ b/model/client.go
@@ -72,3 +72,20 @@ func (c *Client) RotateCluster(request *RotateClusterRequest) (*Cluster, error) 
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
 	}
 }
+
+// DrainNode requests the drain of a K8s cluster node from the rotator server.
+func (c *Client) DrainNode(request *DrainNodeRequest) (*NodeDrain, error) {
+	resp, err := c.doPost(c.buildURL("/api/drain"), request)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return NodeDrainFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}

--- a/model/drain_request.go
+++ b/model/drain_request.go
@@ -28,7 +28,7 @@ func NewDrainNodeRequestFromReader(reader io.Reader) (*DrainNodeRequest, error) 
 
 	err = drainNodeRequest.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "rotate cluster request failed validation")
+		return nil, errors.Wrap(err, "drain cluster request failed validation")
 	}
 	drainNodeRequest.SetDefaults()
 

--- a/model/drain_request.go
+++ b/model/drain_request.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// DrainNodeRequest specifies the parameters for a new cluster node drain.
+type DrainNodeRequest struct {
+	NodeName                string `json:"nodeName,omitempty"`
+	GracePeriod             int    `json:"gracePeriod,omitempty"`
+	MaxDrainRetries         int    `json:"maxDrainRetries,omitempty"`
+	WaitBetweenPodEvictions int    `json:"waitBetweenPodEvictions,omitempty"`
+}
+
+// NewDrainNodeRequestFromReader decodes the request and returns after validation and setting the defaults.
+func NewDrainNodeRequestFromReader(reader io.Reader) (*DrainNodeRequest, error) {
+	var drainNodeRequest DrainNodeRequest
+	err := json.NewDecoder(reader).Decode(&drainNodeRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode node drain request")
+	}
+
+	err = drainNodeRequest.Validate()
+	if err != nil {
+		return nil, errors.Wrap(err, "rotate cluster request failed validation")
+	}
+	drainNodeRequest.SetDefaults()
+
+	return &drainNodeRequest, nil
+}
+
+// Validate validates the values of a node drain request.
+func (request *DrainNodeRequest) Validate() error {
+	if request.NodeName == "" {
+		return errors.New("Node name cannot be empty")
+	}
+	return nil
+}
+
+// SetDefaults sets the default values for a node drain request.
+func (request *DrainNodeRequest) SetDefaults() {}

--- a/model/drain_request.go
+++ b/model/drain_request.go
@@ -13,6 +13,9 @@ type DrainNodeRequest struct {
 	GracePeriod             int    `json:"gracePeriod,omitempty"`
 	MaxDrainRetries         int    `json:"maxDrainRetries,omitempty"`
 	WaitBetweenPodEvictions int    `json:"waitBetweenPodEvictions,omitempty"`
+	DetachNode              bool   `json:"detachNode,omitempty"`
+	TerminateNode           bool   `json:"terminateNode,omitempty"`
+	ClusterID               string `json:"clusterID,omitempty"`
 }
 
 // NewDrainNodeRequestFromReader decodes the request and returns after validation and setting the defaults.

--- a/model/node.go
+++ b/model/node.go
@@ -11,6 +11,9 @@ type NodeDrain struct {
 	GracePeriod             int
 	WaitBetweenPodEvictions int
 	MaxDrainRetries         int
+	DetachNode              bool
+	TerminateNode           bool
+	ClusterID               string
 }
 
 // NodeFromReader decodes a json-encoded node from the given io.Reader.

--- a/model/node.go
+++ b/model/node.go
@@ -5,14 +5,17 @@ import (
 	"io"
 )
 
-// Node represents a K8s node.
-type Node struct {
-	NodeName string
+// NodeDrain represents a K8s node to be drained.
+type NodeDrain struct {
+	NodeName                string
+	GracePeriod             int
+	WaitBetweenPodEvictions int
+	MaxDrainRetries         int
 }
 
 // NodeFromReader decodes a json-encoded node from the given io.Reader.
-func NodeFromReader(reader io.Reader) (*Node, error) {
-	node := Node{}
+func NodeDrainFromReader(reader io.Reader) (*NodeDrain, error) {
+	node := NodeDrain{}
 	decoder := json.NewDecoder(reader)
 	err := decoder.Decode(&node)
 	if err != nil && err != io.EOF {


### PR DESCRIPTION
#### Summary
- Enhance rotator to support node drains
- Enhance rotator to support instance detach/terminate during drain operation

This new feature gives us the ability to drain a cluster node, detach and terminate very slowly and avoid breaking components in nodes with high pod numbers. 


