### PR TITLE
Propagate logger to internal functions as well

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -31,16 +31,17 @@ func initCluster(apiRouter *mux.Router, context *Context) {
 
 // handleRotateCluster responds to POST /api/rotate, beginning the process of rotating a k8s cluster.
 // sample body:
-// {
-//     "clusterID": "12345678",
-//     "maxScaling": 2,
-//     "rotateMasters":  true,
-//     "rotateWorkers": true,
-//     "maxDrainRetries": 10,
-//     "EvictGracePeriod": 60,
-//     "WaitBetweenRotations": 60,
-//     "WaitBetweenDrains": 60,
-// }
+//
+//	{
+//	    "clusterID": "12345678",
+//	    "maxScaling": 2,
+//	    "rotateMasters":  true,
+//	    "rotateWorkers": true,
+//	    "maxDrainRetries": 10,
+//	    "EvictGracePeriod": 60,
+//	    "WaitBetweenRotations": 60,
+//	    "WaitBetweenDrains": 60,
+//	}
 func handleRotateCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	rotateClusterRequest, err := model.NewRotateClusterRequestFromReader(r.Body)

--- a/rotator/helpers.go
+++ b/rotator/helpers.go
@@ -60,7 +60,6 @@ func (autoscalingGroup *AutoscalingGroup) popNodes(popNodes []string) {
 		}
 	}
 	autoscalingGroup.Nodes = updatedList
-	return
 }
 
 // DrainNodes covers all node drain actions.
@@ -87,10 +86,10 @@ func (autoscalingGroup *AutoscalingGroup) DrainNodes(nodesToDrain []string, atte
 		} else if err != nil {
 			return errors.Wrapf(err, "Failed to get node %s", nodeToDrain)
 		} else {
-			err = Drain(clientset, []*corev1.Node{node}, drainOptions, waitBetweenPodEvictions)
+			err = Drain(clientset, []*corev1.Node{node}, drainOptions, waitBetweenPodEvictions, logger)
 			for i := 1; i < attempts && err != nil; i++ {
 				logger.Warnf("Failed to drain node %q on attempt %d, retrying up to %d times", nodesToDrain, i, attempts)
-				err = Drain(clientset, []*corev1.Node{node}, drainOptions, waitBetweenPodEvictions)
+				err = Drain(clientset, []*corev1.Node{node}, drainOptions, waitBetweenPodEvictions, logger)
 			}
 			if err != nil {
 				return errors.Wrapf(err, "Failed to drain node %s", nodeToDrain)


### PR DESCRIPTION
#### Summary

While reviewing the logs on my testing of https://github.com/mattermost/mattermost-cloud/pull/840 I noticed that some of the log lines from the rotator didn't use the provided logger to the method calls (since they didn't have any fields set up). This PR propagates the provided logger to the underlying methods rather than use the global logger variable.

I've tried to add a prefix as well (so we could have `[rotator] xxxxx` as with other calls) but that implies modifying the formatter of the logger, which I may do in the future for log clarity.

I'm unsure if this behaviour was intended, if that was the case, please disregard this PR.

#### Ticket Link

None

